### PR TITLE
Adding the possibility to pass multiple css files as a parameter

### DIFF
--- a/pdfkit/pdfkit.py
+++ b/pdfkit/pdfkit.py
@@ -19,7 +19,6 @@ class PDFKit(object):
     :param options: dict (optional) with wkhtmltopdf options, with or w/o '--'
     :param toc: dict (optional) - toc-specific wkhtmltopdf options, with or w/o '--'
     :param cover: str (optional) - url/filename with a cover html page
-    :param css: str (optional) - path to css file which will be added to input string or a list with multiple paths
     :param configuration: (optional) instance of pdfkit.configuration.Configuration()
     """
 
@@ -163,17 +162,17 @@ class PDFKit(object):
 
     def _prepend_css(self, path):
         if self.source.isUrl() or isinstance(self.source.source, list):
-            raise self.ImproperSourceError('CSS file can be added only to a single '
+            raise self.ImproperSourceError('CSS files can be added only to a single '
                                            'file or string')
 
-        if not hasattr(path, "__iter__"):
+        if not isinstance(path, list):
             path = [path]
 
-        css_data = ""
+        css_data = []
         for p in path:
             with open(p) as f:
-                css_data += f.read()
-                css_data += "\n"
+                css_data.append(f.read())
+        css_data = "\n".join(css_data)
 
         if self.source.isFile():
             with open(self.source.to_s()) as f:

--- a/tests/fixtures/example2.css
+++ b/tests/fixtures/example2.css
@@ -1,0 +1,1 @@
+a { color: blue; }

--- a/tests/pdfkit-tests.py
+++ b/tests/pdfkit-tests.py
@@ -263,6 +263,33 @@ class TestPDFKitGeneration(unittest.TestCase):
         r._prepend_css('fixtures/example.css')
         self.assertIn('<style>%s</style><html>' % css, r.source.to_s())
 
+    def test_multiple_stylesheets_adding_to_the_head(self):
+        #TODO rewrite this part of pdfkit.py
+        css_files = ['fixtures/example.css', 'fixtures/example2.css']
+        r = pdfkit.PDFKit('<html><head></head><body>Hai!</body></html>', 'string',
+                          css=css_files)
+
+        css=[]
+        for css_file in css_files:
+            with open(css_file) as f:
+                css.append(f.read())
+
+        r._prepend_css(css_files)
+        self.assertIn('<style>%s</style>' % "\n".join(css), r.source.to_s())
+
+    def test_multiple_stylesheet_adding_without_head_tag(self):
+        css_files = ['fixtures/example.css', 'fixtures/example2.css']
+        r = pdfkit.PDFKit('<html><body>Hai!</body></html>', 'string',
+                          options={'quiet': None}, css=css_files)
+
+        css=[]
+        for css_file in css_files:
+            with open(css_file) as f:
+                css.append(f.read())
+
+        r._prepend_css(css_files)
+        self.assertIn('<style>%s</style><html>' % "\n".join(css), r.source.to_s())
+
     def test_stylesheet_throw_error_when_url(self):
         r = pdfkit.PDFKit('http://ya.ru', 'url', css='fixtures/example.css')
 


### PR DESCRIPTION
Today, we can pass only one CSS file to instantiate PDFKit. 
With this patch, we'll be able to pass multiple CSS files as a list of paths.
It still accepts only one file as a string.
