### PR TITLE
Put cover before TOC in the command args

### DIFF
--- a/pdfkit/api.py
+++ b/pdfkit/api.py
@@ -4,27 +4,27 @@ from .pdfkit import PDFKit
 from .pdfkit import Configuration
 
 
-def from_url(url, output_path, options=None, toc=None, cover=None, configuration=None):
+def from_url(url, output_path, options=None, cover=None, toc=None, configuration=None):
     """
     Convert file of files from URLs to PDF document
 
     :param url: URL or list of URLs to be saved
     :param output_path: path to output PDF file. False means file will be returned as string.
     :param options: (optional) dict with wkhtmltopdf global and page options, with or w/o '--'
-    :param toc: (optional) dict with toc-specific wkhtmltopdf options, with or w/o '--'
     :param cover: (optional) string with url/filename with a cover html page
+    :param toc: (optional) dict with toc-specific wkhtmltopdf options, with or w/o '--'
     :param configuration: (optional) instance of pdfkit.configuration.Configuration()
 
     Returns: True on success
     """
 
-    r = PDFKit(url, 'url', options=options, toc=toc, cover=cover,
+    r = PDFKit(url, 'url', options=options, cover=cover, toc=toc,
                configuration=configuration)
 
     return r.to_pdf(output_path)
 
 
-def from_file(input, output_path, options=None, toc=None, cover=None, css=None,
+def from_file(input, output_path, options=None, cover=None, toc=None, css=None,
               configuration=None):
     """
     Convert HTML file or files to PDF document
@@ -32,21 +32,21 @@ def from_file(input, output_path, options=None, toc=None, cover=None, css=None,
     :param input: path to HTML file or list with paths or file-like object
     :param output_path: path to output PDF file. False means file will be returned as string.
     :param options: (optional) dict with wkhtmltopdf options, with or w/o '--'
-    :param toc: (optional) dict with toc-specific wkhtmltopdf options, with or w/o '--'
     :param cover: (optional) string with url/filename with a cover html page
+    :param toc: (optional) dict with toc-specific wkhtmltopdf options, with or w/o '--'
     :param css: (optional) string with path to css file which will be added to a single input file
     :param configuration: (optional) instance of pdfkit.configuration.Configuration()
 
     Returns: True on success
     """
 
-    r = PDFKit(input, 'file', options=options, toc=toc, cover=cover, css=css,
+    r = PDFKit(input, 'file', options=options, cover=cover, toc=toc, css=css,
                configuration=configuration)
 
     return r.to_pdf(output_path)
 
 
-def from_string(input, output_path, options=None, toc=None, cover=None, css=None,
+def from_string(input, output_path, options=None, cover=None, toc=None, css=None,
                 configuration=None):
     """
     Convert given string or strings to PDF document
@@ -54,15 +54,15 @@ def from_string(input, output_path, options=None, toc=None, cover=None, css=None
     :param input: string with a desired text. Could be a raw text or a html file
     :param output_path: path to output PDF file. False means file will be returned as string.
     :param options: (optional) dict with wkhtmltopdf options, with or w/o '--'
-    :param toc: (optional) dict with toc-specific wkhtmltopdf options, with or w/o '--'
     :param cover: (optional) string with url/filename with a cover html page
+    :param toc: (optional) dict with toc-specific wkhtmltopdf options, with or w/o '--'
     :param css: (optional) string with path to css file which will be added to a input string
     :param configuration: (optional) instance of pdfkit.configuration.Configuration()
 
     Returns: True on success
     """
 
-    r = PDFKit(input, 'string', options=options, toc=toc, cover=cover, css=css,
+    r = PDFKit(input, 'string', options=options, cover=cover, toc=toc, css=css,
                configuration=configuration)
 
     return r.to_pdf(output_path)

--- a/pdfkit/pdfkit.py
+++ b/pdfkit/pdfkit.py
@@ -31,7 +31,7 @@ class PDFKit(object):
         def __str__(self):
             return self.msg
 
-    def __init__(self, url_or_file, type_, options=None, toc=None, cover=None,
+    def __init__(self, url_or_file, type_, options=None, cover=None, toc=None,
                  css=None, configuration=None):
 
         self.source = Source(url_or_file, type_)
@@ -45,9 +45,9 @@ class PDFKit(object):
         if options is not None: self.options.update(options)
         self.options = self._normalize_options(self.options)
 
+        self.cover = cover
         toc = {} if toc is None else toc
         self.toc = self._normalize_options(toc)
-        self.cover = cover
         self.css = css
         self.stylesheets = []
 
@@ -60,12 +60,12 @@ class PDFKit(object):
         args += list(chain.from_iterable(list(self.options.items())))
         args = [_f for _f in args if _f]
 
-        if self.toc:
-            args.append('toc')
-            args += list(chain.from_iterable(list(self.toc.items())))
         if self.cover:
             args.append('cover')
             args.append(self.cover)
+        if self.toc:
+            args.append('toc')
+            args += list(chain.from_iterable(list(self.toc.items())))
 
         # If the source is a string then we will pipe it into wkhtmltopdf
         # If the source is file-like then we will read from it and pipe it in

--- a/tests/pdfkit-tests.py
+++ b/tests/pdfkit-tests.py
@@ -190,7 +190,7 @@ class TestPDFKitCommandGeneration(unittest.TestCase):
         }
         r = pdfkit.PDFKit('html', 'string', options=options, toc={'xsl-style-sheet': 'test.xsl'}, cover='test.html')
         command = r.command()
-        self.assertEqual(command[-7:], ['toc', '--xsl-style-sheet', 'test.xsl', 'cover', 'test.html', '-', '-'])
+        self.assertEqual(command[-7:], ['cover', 'test.html', 'toc', '--xsl-style-sheet', 'test.xsl', '-', '-'])
 
     def test_outline_options(self):
         options = {


### PR DESCRIPTION
I needed the cover to show up before the TOC in wkhtmltopdf 0.12, so I changed the order of both args in the `command` function and updated the corresponding unit test.
I also changed the order of the `toc` and `cover` kwargs and their documentation everywhere, so the kwargs remain consistent with the order of the command arguments.