### PR TITLE
Allow repeatable options and multiple option values per option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ If you wish to further process generated PDF, you can read it to a variable:
     # Use False instead of output path to save pdf to a variable
     pdf = pdfkit.from_url('http://google.com', False)
 
-You can specify all wkhtmltopdf `options <http://wkhtmltopdf.org/usage/wkhtmltopdf.txt>`_. You can drop '--' in option name. If option without value, use *None, False* or *''* for dict value:
+You can specify all wkhtmltopdf `options <http://wkhtmltopdf.org/usage/wkhtmltopdf.txt>`_. You can drop '--' in option name. If option without value, use *None, False* or *''* for dict value:. For repeatable options (incl. allow, cookies, custom-header, post, postfile, run-script, replace) you may use a list or a tuple. With option that need multiple values (e.g. --custom-header Authorization secret) we may use a 2-tuple.
 
 .. code-block:: python
 
@@ -78,6 +78,10 @@ You can specify all wkhtmltopdf `options <http://wkhtmltopdf.org/usage/wkhtmltop
 	    'margin-bottom': '0.75in',
 	    'margin-left': '0.75in',
 	    'encoding': "UTF-8",
+	    'cookies': [
+	    	('cookie-name1', 'cookie-value1'),
+	    	('cookie-name2', 'cookie-value2'),
+	    ],
 	    'no-outline': None
 	}
 

--- a/pdfkit/pdfkit.py
+++ b/pdfkit/pdfkit.py
@@ -182,11 +182,12 @@ class PDFKit(object):
                 normalized_key = '--%s' % self._normalize_arg(key)
             else:
                 normalized_key = self._normalize_arg(key)
+                
             if isinstance(value, (list, tuple)):
                 for optval in value:
                     yield (normalized_key, optval)
-
-            yield (normalized_key, str(value) if value else value)
+            else:
+                yield (normalized_key, str(value) if value else value)
 
 
     def _normalize_arg(self, arg):

--- a/tests/pdfkit-tests.py
+++ b/tests/pdfkit-tests.py
@@ -42,11 +42,16 @@ class TestPDFKitInitialization(unittest.TestCase):
 
     def test_options_parsing(self):
         r = pdfkit.PDFKit('html', 'string', options={'page-size': 'Letter'})
-        self.assertTrue(r.options['--page-size'])
+        test_command = r.command('test')
+        idx = test_command.index('--page-size')  # Raise exception in case of not found
+        self.assertTrue(test_command[idx+1] == 'Letter')
 
     def test_options_parsing_with_dashes(self):
         r = pdfkit.PDFKit('html', 'string', options={'--page-size': 'Letter'})
-        self.assertTrue(r.options['--page-size'])
+        
+        test_command = r.command('test')
+        idx = test_command.index('--page-size')  # Raise exception in case of not found
+        self.assertTrue(test_command[idx+1] == 'Letter')
 
     def test_custom_configuration(self):
         conf = pdfkit.configuration()

--- a/tests/pdfkit-tests.py
+++ b/tests/pdfkit-tests.py
@@ -48,10 +48,39 @@ class TestPDFKitInitialization(unittest.TestCase):
 
     def test_options_parsing_with_dashes(self):
         r = pdfkit.PDFKit('html', 'string', options={'--page-size': 'Letter'})
-        
+
         test_command = r.command('test')
         idx = test_command.index('--page-size')  # Raise exception in case of not found
         self.assertTrue(test_command[idx+1] == 'Letter')
+
+    def test_repeatable_options(self):
+        roptions={
+            '--page-size': 'Letter',
+            'cookies': [ 
+                ('test_cookie1','cookie_value1'),
+                ('test_cookie2','cookie_value2'), 
+            ]
+        }
+
+        r = pdfkit.PDFKit('html', 'string', options=roptions)
+
+        test_command = r.command('test')
+
+        idx1 = test_command.index('--page-size')  # Raise exception in case of not found
+        self.assertTrue(test_command[idx1 + 1] == 'Letter')
+
+        self.assertTrue(test_command.count('--cookies') == 2)
+
+        idx2 = test_command.index('--cookies')
+        self.assertTrue(test_command[idx2 + 1] == 'test_cookie1')
+        self.assertTrue(test_command[idx2 + 2] == 'cookie_value1')
+
+        idx3 = test_command.index('--cookies', idx2 + 2)
+        self.assertTrue(test_command[idx3 + 1] == 'test_cookie2')
+        self.assertTrue(test_command[idx3 + 2] == 'cookie_value2')
+
+
+
 
     def test_custom_configuration(self):
         conf = pdfkit.configuration()

--- a/tests/pdfkit-tests.py
+++ b/tests/pdfkit-tests.py
@@ -79,9 +79,6 @@ class TestPDFKitInitialization(unittest.TestCase):
         self.assertTrue(test_command[idx3 + 1] == 'test_cookie2')
         self.assertTrue(test_command[idx3 + 2] == 'cookie_value2')
 
-
-
-
     def test_custom_configuration(self):
         conf = pdfkit.configuration()
         self.assertEqual('pdfkit-', conf.meta_tag_prefix)


### PR DESCRIPTION
Allow repeatable options (incl. allow, cookies, custom-header, post, postfile, run-script, replace) by using a list or a tuple. 

For options that need multiple values (e.g. --custom-header authorization secret) we may use a 2-tuple.