### PR TITLE
 Options to set cookies

### DIFF
--- a/pdfkit/api.py
+++ b/pdfkit/api.py
@@ -4,7 +4,7 @@ from .pdfkit import PDFKit
 from .pdfkit import Configuration
 
 
-def from_url(url, output_path, options=None, toc=None, cover=None, configuration=None):
+def from_url(url, output_path, options=None, toc=None, cover=None, configuration=None, cookies=None):
     """
     Convert file of files from URLs to PDF document
 
@@ -19,7 +19,7 @@ def from_url(url, output_path, options=None, toc=None, cover=None, configuration
     """
 
     r = PDFKit(url, 'url', options=options, toc=toc, cover=cover,
-               configuration=configuration)
+               configuration=configuration, cookies=cookies)
 
     return r.to_pdf(output_path)
 

--- a/pdfkit/pdfkit.py
+++ b/pdfkit/pdfkit.py
@@ -32,7 +32,7 @@ class PDFKit(object):
             return self.msg
 
     def __init__(self, url_or_file, type_, options=None, toc=None, cover=None,
-                 css=None, configuration=None):
+                 css=None, configuration=None, cookies=None):
 
         self.source = Source(url_or_file, type_)
         self.configuration = (Configuration() if configuration is None
@@ -44,6 +44,8 @@ class PDFKit(object):
             self.options.update(self._find_options_in_meta(url_or_file))
         if options is not None: self.options.update(options)
         self.options = self._normalize_options(self.options)
+
+        self.cookies = cookies
 
         toc = {} if toc is None else toc
         self.toc = self._normalize_options(toc)
@@ -66,6 +68,8 @@ class PDFKit(object):
         if self.cover:
             args.append('cover')
             args.append(self.cover)
+        if self.cookies:
+            args += list(chain.from_iterable(('--cookie', cookie, self.cookies[cookie]) for cookie in self.cookies))
 
         # If the source is a string then we will pipe it into wkhtmltopdf
         # If the source is file-like then we will read from it and pipe it in


### PR DESCRIPTION
Wkhtmltopdf allows for cookies to be set. To set multiple cookes the '--cokies' parameter must be repeated, so the options dict does not work for setting multiple cookies. 

I introduced a 'cookies' parameter where you can set a dict of cookies.
#### Usage example / Test:

```
import pdfkit

cookies = {'a': 'b', 'b':'c'}
pdfkit.from_url("http://www.html-kit.com/tools/cookietester/", "cookies.pdf", cookies=cookies, configuration=pdfkit.configuration(wkhtmltopdf='./wkhtmltox/bin/wkhtmltopdf'))
```
