### PR TITLE
Catch AttributeError raised by decode in python3.5

### DIFF
--- a/pdfkit/pdfkit.py
+++ b/pdfkit/pdfkit.py
@@ -37,7 +37,10 @@ class PDFKit(object):
         self.source = Source(url_or_file, type_)
         self.configuration = (Configuration() if configuration is None
                               else configuration)
-        self.wkhtmltopdf = self.configuration.wkhtmltopdf.decode('utf-8')
+        try:
+            self.wkhtmltopdf = self.configuration.wkhtmltopdf.decode('utf-8')
+        except AttributeError:
+            self.wkhtmltopdf = self.configuration.wkhtmltopdf
 
         self.options = dict()
         if self.source.isString():


### PR DESCRIPTION
When calling `pdfkit.from_string` in python3.5 an `AttributeError` is raised.

This is because strings do not have the `decode` attr in python3.5.

So we catch the error and revert to the default string.
