### PR TITLE
use errand-boy instead of subprocess.Popen

### DIFF
--- a/pdfkit/configuration.py
+++ b/pdfkit/configuration.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
-import subprocess
 import sys
+from errand_boy.transports.unixsocket import UNIXSocketTransport
+
+errand_boy_transport = UNIXSocketTransport()
 
 
 class Configuration(object):
@@ -10,12 +12,16 @@ class Configuration(object):
         self.wkhtmltopdf = wkhtmltopdf
 
         if not self.wkhtmltopdf:
-            if sys.platform == 'win32':
-                self.wkhtmltopdf = subprocess.Popen(
-                    ['where', 'wkhtmltopdf'], stdout=subprocess.PIPE).communicate()[0].strip()
-            else:
-                self.wkhtmltopdf = subprocess.Popen(
-                    ['which', 'wkhtmltopdf'], stdout=subprocess.PIPE).communicate()[0].strip()
+            with errand_boy_transport.get_session() as session:
+                subprocess = session.subprocess
+                if sys.platform == 'win32':
+                    stdout, _ = subprocess.Popen(
+                        ['where', 'wkhtmltopdf'], stdout=subprocess.PIPE).communicate()
+                    self.wkhtmltopdf = stdout.strip()
+                else:
+                    stdout, _ = subprocess.Popen(
+                        ['which', 'wkhtmltopdf'], stdout=subprocess.PIPE).communicate()
+                    self.wkhtmltopdf = stdout.strip()
 
         try:
             with open(self.wkhtmltopdf) as f:

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     long_description=long_description(),
     download_url='https://github.com/JazzCore/python-pdfkit',
     license=pdfkit.__license__,
+    install_requires=['errand-boy'],
     tests_require=['pytest'],
     cmdclass = {'test': PyTest},
     packages=['pdfkit'],


### PR DESCRIPTION
We use pdfkit to render PDF documents during a HTTP request in Django. uWSGI processes handling our application tend to have huge memory footprint. Popen() uses fork() syscall, which copies the parent process memory.

errand-boy server is required to use this branch: https://github.com/greyside/errand-boy
