### PR TITLE
Adding option to prepend cover to TOC

### DIFF
--- a/pdfkit/api.py
+++ b/pdfkit/api.py
@@ -4,7 +4,8 @@ from .pdfkit import PDFKit
 from .pdfkit import Configuration
 
 
-def from_url(url, output_path, options=None, toc=None, cover=None, configuration=None):
+def from_url(url, output_path, options=None, toc=None, cover=None,
+             configuration=None, cover_first=False):
     """
     Convert file of files from URLs to PDF document
 
@@ -14,18 +15,19 @@ def from_url(url, output_path, options=None, toc=None, cover=None, configuration
     :param toc: (optional) dict with toc-specific wkhtmltopdf options, with or w/o '--'
     :param cover: (optional) string with url/filename with a cover html page
     :param configuration: (optional) instance of pdfkit.configuration.Configuration()
+    :param configuration_first: (optional) if True, cover always precedes TOC
 
     Returns: True on success
     """
 
     r = PDFKit(url, 'url', options=options, toc=toc, cover=cover,
-               configuration=configuration)
+               configuration=configuration, cover_first=cover_first)
 
     return r.to_pdf(output_path)
 
 
 def from_file(input, output_path, options=None, toc=None, cover=None, css=None,
-              configuration=None):
+              configuration=None, cover_first=False):
     """
     Convert HTML file or files to PDF document
 
@@ -36,18 +38,19 @@ def from_file(input, output_path, options=None, toc=None, cover=None, css=None,
     :param cover: (optional) string with url/filename with a cover html page
     :param css: (optional) string with path to css file which will be added to a single input file
     :param configuration: (optional) instance of pdfkit.configuration.Configuration()
+    :param configuration_first: (optional) if True, cover always precedes TOC
 
     Returns: True on success
     """
 
     r = PDFKit(input, 'file', options=options, toc=toc, cover=cover, css=css,
-               configuration=configuration)
+               configuration=configuration, cover_first=cover_first)
 
     return r.to_pdf(output_path)
 
 
 def from_string(input, output_path, options=None, toc=None, cover=None, css=None,
-                configuration=None):
+                configuration=None, cover_first=False):
     """
     Convert given string or strings to PDF document
 
@@ -58,12 +61,13 @@ def from_string(input, output_path, options=None, toc=None, cover=None, css=None
     :param cover: (optional) string with url/filename with a cover html page
     :param css: (optional) string with path to css file which will be added to a input string
     :param configuration: (optional) instance of pdfkit.configuration.Configuration()
+    :param configuration_first: (optional) if True, cover always precedes TOC
 
     Returns: True on success
     """
 
     r = PDFKit(input, 'string', options=options, toc=toc, cover=cover, css=css,
-               configuration=configuration)
+               configuration=configuration, cover_first=cover_first)
 
     return r.to_pdf(output_path)
 

--- a/pdfkit/pdfkit.py
+++ b/pdfkit/pdfkit.py
@@ -32,7 +32,7 @@ class PDFKit(object):
             return self.msg
 
     def __init__(self, url_or_file, type_, options=None, toc=None, cover=None,
-                 css=None, configuration=None):
+                 css=None, configuration=None, cover_first=False):
 
         self.source = Source(url_or_file, type_)
         self.configuration = (Configuration() if configuration is None
@@ -48,6 +48,7 @@ class PDFKit(object):
         toc = {} if toc is None else toc
         self.toc = self._normalize_options(toc)
         self.cover = cover
+        self.cover_first = cover_first
         self.css = css
         self.stylesheets = []
 
@@ -60,10 +61,13 @@ class PDFKit(object):
         args += list(chain.from_iterable(list(self.options.items())))
         args = [_f for _f in args if _f]
 
+        if self.cover and self.cover_first:
+            args.append('cover')
+            args.append(self.cover)
         if self.toc:
             args.append('toc')
             args += list(chain.from_iterable(list(self.toc.items())))
-        if self.cover:
+        if self.cover and not self.cover_first:
             args.append('cover')
             args.append(self.cover)
 


### PR DESCRIPTION
In #23, @signalkraft proposed to always prepend cover to TOC by switching the order of the command line arguments.

This is, IMHO, the right thing to do, but it would change pdfkit's previous behavior. This PR adds to each API one more parameter that lets you choose which one you want to go first between cover and TOC.

The new parameter, `cover_first`, will default to `False`, so the default behavior will stay exactly the same.