### PR TITLE
Multiple option value support (e.g. --custom-header)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 .idea
 *.pyc
 
+# Build
 .cache
 .eggs
 pdfkit.egg-info
+
+# Tests
+.tox
+.python-version

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .idea
 *.pyc
+
+.cache
+.eggs
+pdfkit.egg-info

--- a/pdfkit/pdfkit.py
+++ b/pdfkit/pdfkit.py
@@ -7,6 +7,11 @@ from .configuration import Configuration
 from itertools import chain
 import io
 import codecs
+try:
+    # Python 2.x and 3.x support for checking string types
+    assert basestring
+except NameError:
+    basestring = str
 
 
 class PDFKit(object):

--- a/tests/pdfkit-tests.py
+++ b/tests/pdfkit-tests.py
@@ -48,6 +48,19 @@ class TestPDFKitInitialization(unittest.TestCase):
         r = pdfkit.PDFKit('html', 'string', options={'--page-size': 'Letter'})
         self.assertTrue(r.options['--page-size'])
 
+    def test_options_parsing_with_tuple(self):
+        r = pdfkit.PDFKit('html', 'string', options={'--custom-header':
+                                                     ('Accept-Encoding',
+                                                      'gzip')})
+        self.assertTrue(r.options['--custom-header'])
+        r = pdfkit.PDFKit('html', 'string', options={'custom-header':
+                                                     ('Accept-Encoding',
+                                                      'gzip')})
+        self.assertTrue(r.options['--custom-header'])
+        self.assertTrue("--custom-header" in r.command())
+        self.assertTrue("Accept-Encoding" in r.command())
+        self.assertTrue("gzip" in r.command())
+
     def test_custom_configuration(self):
         conf = pdfkit.configuration()
         self.assertEqual('pdfkit-', conf.meta_tag_prefix)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py27,py33,py34,py35
+
+[testenv]
+deps = pytest
+commands = python setup.py test


### PR DESCRIPTION
Adds support for flags requiring multiple values by accepting option value as a `tuple` and then passing in the double argument to `wkhtmltopdf`.

Additionally, this adds `tox` configuration for testing in multiple versions of Python. Also, added a few things to `.gitignore` that I found were created during testing but not ignored (like `.eggs`).

Closes JazzCore/python-pdfkit#41
Closes JazzCore/python-pdfkit#45
Closes JazzCore/python-pdfkit#53