### PR TITLE
Allow files that were generated with some errors to return

### DIFF
--- a/pdfkit/pdfkit.py
+++ b/pdfkit/pdfkit.py
@@ -152,11 +152,26 @@ class PDFKit(object):
                           'Go to the link below for more information\n'
                           'https://github.com/JazzCore/python-pdfkit/wiki/Using-wkhtmltopdf-without-X-server' % stderr)
 
-        if 'Error' in stderr:
-            raise IOError('wkhtmltopdf reported an error:\n' + stderr)
+        """
+        Exit Code   Explanation
+        0   All OK
+        1   PDF generated OK, but some request(s) did not return HTTP 200
+        2   Could not something something
+        X   Could not write PDF: File in use
+        Y   Could not write PDF: No write permission
+        Z   PDF generated OK, but some JavaScript requests(s) timeouted
+        A   Invalid arguments provided
+        B   Could not find input file(s)
+        C   Process timeout
+        """
+        valid_codes = [0, 1, 'Z']
+        
+        if exit_code not in valid_codes:
+            if 'Error' in stderr:
+                raise IOError('wkhtmltopdf reported an error:\n' + stderr)
 
-        if exit_code != 0:
-            raise IOError("wkhtmltopdf exited with non-zero code {0}. error:\n{1}".format(exit_code, stderr))
+            if exit_code != 0:
+                raise IOError("wkhtmltopdf exited with non-zero code {0}. error:\n{1}".format(exit_code, stderr))
 
         # Since wkhtmltopdf sends its output to stderr we will capture it
         # and properly send to stdout


### PR DESCRIPTION
There are three possible exit statuses from wkhtmltopdf that result in a working file: 0, 1 and Z
(See table here: https://github.com/KnpLabs/snappy/issues/177#issuecomment-141008420) Right now python-pdfkit only responds to code 0.

I'm finding a hand full of minor errors and warnings that result in a working PDF. I've done some research about how to resolve these wkhtmltopdf warnings, but haven't found any solutions. Here's my error output, for reference:

    There was an error generating the brochure preview: wkhtmltopdf reported an error:
    Loading pages (1/6)
    QFont::setPixelSize: Pixel size <= 0 (0)                     ] 10%
    Counting pages (2/6)                                               
    Warning: Received createRequest signal on a disposed ResourceObject's NetworkAccessManager. This might be an indication of an iframe taking too long to load.
    Resolving links (4/6)
    Loading headers and footers (5/6)                                           
    Printing pages (6/6)
    Done                                                                      
    Exit with code 1 due to network error: ContentNotFoundError

Browsing through the ticket backlog at wkhtmltopdf, they have 800+ open issues. This makes me think that they are working on the most pressing issues, and there's a lot to be ironed out. 

With all this in mind, I wanted to request that the default behavior of the python-pdfkit is to return successfully if it returns any one of the three exit codes because it just seems more likely to return a semi-working code (1 and Z) than a fully working code (0).