### PR TITLE
Only use stderr as str after getting non-zero exit code

### DIFF
--- a/pdfkit/pdfkit.py
+++ b/pdfkit/pdfkit.py
@@ -177,7 +177,7 @@ class PDFKit(object):
                                       'Check whhtmltopdf output without \'quiet\' '
                                       'option' % ' '.join(args))
                     return True
-            except IOError as e:
+            except (IOError, OSError) as e:
                 raise IOError('Command failed: %s\n'
                               'Check whhtmltopdf output without \'quiet\' option\n'
                               '%s ' %(' '.join(args)),e)

--- a/pdfkit/pdfkit.py
+++ b/pdfkit/pdfkit.py
@@ -163,7 +163,7 @@ class PDFKit(object):
         # Since wkhtmltopdf sends its output to stderr we will capture it
         # and properly send to stdout
         if '--quiet' not in args:
-            sys.stdout.write(stderr)
+            sys.stdout.write(stderr.decode('utf-8'))
 
         if not path:
             return stdout

--- a/pdfkit/pdfkit.py
+++ b/pdfkit/pdfkit.py
@@ -140,23 +140,25 @@ class PDFKit(object):
             input = None
         stdout, stderr = result.communicate(input=input)
         stderr = stderr or stdout
-        try:
-            stderr = stderr.decode('utf-8')
-        except UnicodeDecodeError:
-            stderr = ''
+
         exit_code = result.returncode
-
-        if 'cannot connect to X server' in stderr:
-            raise IOError('%s\n'
-                          'You will need to run wkhtmltopdf within a "virtual" X server.\n'
-                          'Go to the link below for more information\n'
-                          'https://github.com/JazzCore/python-pdfkit/wiki/Using-wkhtmltopdf-without-X-server' % stderr)
-
-        if 'Error' in stderr:
-            raise IOError('wkhtmltopdf reported an error:\n' + stderr)
-
         if exit_code != 0:
-            raise IOError("wkhtmltopdf exited with non-zero code {0}. error:\n{1}".format(exit_code, stderr))
+            try:
+                stderr = stderr.decode('utf-8')
+            except UnicodeDecodeError:
+                stderr = ''
+
+            if 'cannot connect to X server' in stderr:
+                raise IOError('%s\n'
+                            'You will need to run wkhtmltopdf within a "virtual" X server.\n'
+                            'Go to the link below for more information\n'
+                            'https://github.com/JazzCore/python-pdfkit/wiki/Using-wkhtmltopdf-without-X-server' % stderr)
+
+            if 'Error' in stderr:
+                raise IOError('wkhtmltopdf reported an error:\n' + stderr)
+
+            error_msg = stderr or 'Unknown Error'
+            raise IOError("wkhtmltopdf exited with non-zero code {0}. error:\n{1}".format(exit_code, error_msg))
 
         # Since wkhtmltopdf sends its output to stderr we will capture it
         # and properly send to stdout


### PR DESCRIPTION
We shouldn't always `.decode('utf-8')` the pdf contents, because it will be binary data. Only try to decode after `wkhtmltopdf` returns a non-zero exit code. This prevents setting the pdf contents to empty string when no error occurred.