### PR TITLE
assertRegexpMatches deprecated

### DIFF
--- a/tests/pdfkit-tests.py
+++ b/tests/pdfkit-tests.py
@@ -402,7 +402,7 @@ class TestPDFKitGeneration(unittest.TestCase):
             r.to_pdf()
 
         raised_exception = cm.exception
-        self.assertRegexpMatches(str(raised_exception), '^wkhtmltopdf exited with non-zero code 1. error:\nUnknown long argument --bad-option\r?\n')
+        self.assertRegex(str(raised_exception), '^wkhtmltopdf exited with non-zero code 1. error:\nUnknown long argument --bad-option\r?\n')
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`unittest.TestCase.assertRegexpMatches` was changed to `unittest.TestCase.assertRegexp` in Python 3.2. Unit tests report the following warning:

`../tests/pdfkit-tests.py:408: DeprecationWarning: Please use assertRegex instead.`

[https://docs.python.org/3.5/library/unittest.html#deprecated-aliases](https://docs.python.org/3.5/library/unittest.html#deprecated-aliases)