### PR TITLE
fix wkhtml2pdf install on travis

### DIFF
--- a/tests/pdfkit-tests.py
+++ b/tests/pdfkit-tests.py
@@ -6,6 +6,10 @@ import codecs
 import unittest
 
 
+if sys.version_info[0] == 2 and sys.version_info[1] == 7:
+    unittest.TestCase.assertRegex = unittest.TestCase.assertRegexpMatches
+
+
 #Prepend ../ to PYTHONPATH so that we can import PDFKIT form there.
 TESTS_ROOT = os.path.abspath(os.path.dirname(__file__))
 sys.path.insert(0, os.path.realpath(os.path.join(TESTS_ROOT, '..')))
@@ -80,9 +84,9 @@ class TestPDFKitInitialization(unittest.TestCase):
     def test_repeatable_options(self):
         roptions = {
             '--page-size': 'Letter',
-            'cookies': [ 
+            'cookies': [
                 ('test_cookie1','cookie_value1'),
-                ('test_cookie2','cookie_value2'), 
+                ('test_cookie2','cookie_value2'),
             ]
         }
 

--- a/travis/before-script.sh
+++ b/travis/before-script.sh
@@ -1,8 +1,10 @@
-#!/bin/sh
+#!/usr/bin/env sh
+
+WKHTML2PDF_VERSION='0.12.4'
 
 sudo apt-get install -y openssl build-essential xorg libssl-dev
-wget http://download.gna.org/wkhtmltopdf/0.12/0.12.3/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz
-tar -xJf wkhtmltox-0.12.3_linux-generic-amd64.tar.xz
+wget "https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${WKHTML2PDF_VERSION}/wkhtmltox-${WKHTML2PDF_VERSION}_linux-generic-amd64.tar.xz"
+tar -xJf "wkhtmltox-${WKHTML2PDF_VERSION}_linux-generic-amd64.tar.xz"
 cd wkhtmltox
 sudo chown root:root bin/wkhtmltopdf
 sudo cp -r * /usr/


### PR DESCRIPTION
Uses new download link from GitHub, since old download url isn't available anymore.