### PR TITLE
Update Readme for python3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Installation
 
 .. code-block:: bash
 
-	$ pip install pdfkit
+	$ pip install pdfkit  (or pip3 for python3)
 
 2. Install wkhtmltopdf:
 


### PR DESCRIPTION
I had to search on internet to understand why I was not able to import pdfkit in python3. I just did not know that I had to use pip3 instead of pip. Indicating this here could same hours of search or premature abandon :)