### PR TITLE
Support for passing custom OS environment to Popen

### DIFF
--- a/pdfkit/configuration.py
+++ b/pdfkit/configuration.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
+import os
 import subprocess
 import sys
 
 
 class Configuration(object):
-    def __init__(self, wkhtmltopdf='', meta_tag_prefix='pdfkit-'):
+    def __init__(self, wkhtmltopdf='', meta_tag_prefix='pdfkit-', environ=''):
         self.meta_tag_prefix = meta_tag_prefix
 
         self.wkhtmltopdf = wkhtmltopdf
@@ -25,3 +26,12 @@ class Configuration(object):
                           'If this file exists please check that this process can '
                           'read it. Otherwise please install wkhtmltopdf - '
                           'https://github.com/JazzCore/python-pdfkit/wiki/Installing-wkhtmltopdf' % self.wkhtmltopdf)
+
+        self.environ = environ
+
+        if not self.environ:
+            self.environ = os.environ
+
+        for key in self.environ.keys():
+            if not isinstance(self.environ[key], str):
+                self.environ[key] = str(self.environ[key])

--- a/pdfkit/pdfkit.py
+++ b/pdfkit/pdfkit.py
@@ -51,6 +51,8 @@ class PDFKit(object):
         if self.source.isString():
             self.options.update(self._find_options_in_meta(url_or_file))
 
+        self.environ = self.configuration.environ
+
         if options is not None: self.options.update(options)
 
         self.toc = {} if toc is None else toc
@@ -125,9 +127,9 @@ class PDFKit(object):
 
     def to_pdf(self, path=None):
         args = self.command(path)
-
+        
         result = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                                  stderr=subprocess.PIPE)
+                                  stderr=subprocess.PIPE, env=self.environ)
 
         # If the source is a string then we will pipe it into wkhtmltopdf.
         # If we want to add custom CSS to file then we read input file to


### PR DESCRIPTION
Passing custom environment variables such as DISPLAY to wkhtmltopdf is necessary when using pdfkit with xvfbwrapper running in a cgi / wsgi setup.

Code example for usage with Xvfb:

import pdfkit
from xvfbwrapper import Xvfb

input = "Test"
input.encode("utf8")
vdisplay = Xvfb()
vdisplay.start()
env = os.environ
env['DISPLAY'] = ":%s" % vdisplay.vdisplay_num
configuration = pdfkit.configuration(environ=env)
pdfkit.from_string(input, 'out.pdf', configuration=configuration)
vdisplay.stop()
