### PR TITLE
Fix UnicodeDecodeError when from_string source contains Unicode characters

### DIFF
--- a/pdfkit/pdfkit.py
+++ b/pdfkit/pdfkit.py
@@ -204,7 +204,7 @@ class PDFKit(object):
                 for optval in value:
                     yield (normalized_key, optval)
             else:
-                yield (normalized_key, str(value) if value else value)
+                yield (normalized_key, unicode(value) if value else value)
 
 
     def _normalize_arg(self, arg):


### PR DESCRIPTION
Since all arguments get normalized, including the string you pass to `pdfkit.from_string`, `yield (normalized_key, str(value) if value else value)` will raise `UnicodeDecodeError` if your input contains Unicode characters.