### PR TITLE
Fix configurator when where returns multiple lines

### DIFF
--- a/pdfkit/configuration.py
+++ b/pdfkit/configuration.py
@@ -14,6 +14,9 @@ class Configuration(object):
             if sys.platform == 'win32':
                 self.wkhtmltopdf = subprocess.Popen(
                     ['where', 'wkhtmltopdf'], stdout=subprocess.PIPE).communicate()[0].strip()
+                lines = self.wkhtmltopdf.splitlines()
+                if len(lines) > 0:
+                    self.wkhtmltopdf = lines[0].strip()                
             else:
                 self.wkhtmltopdf = subprocess.Popen(
                     ['which', 'wkhtmltopdf'], stdout=subprocess.PIPE).communicate()[0].strip()


### PR DESCRIPTION
Fixes:
```
18:13:46.171 CRITI Uncaught exception:
18:13:46.176 CRITI Traceback (most recent call last):
18:13:46.177 CRITI   File "C:\Python3\lib\site-packages\pdfkit\configuration.py", line 22, in __init__
18:13:46.178 CRITI     with open(self.wkhtmltopdf) as f:
18:13:46.179 CRITI OSError: [Errno 22] Invalid argument: b'C:\\Program Files\\wkhtmltopdf\\bin\\wkhtmltopdf.exe\r\nC:\\ProgramData\\chocolatey\\bin\\wkhtmltopdf.exe'
```