### PR TITLE
Add timeout to wkhtmltopdf command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: python
 python:
   - 2.7
-  - 3.2
-  - 3.3
   - 3.4
   - 3.5
+  - 3.6
+  - 3.7
+  - 3.8
 before_script: "./travis/before-script.sh"
 script: nosetests -w tests
 notifications:

--- a/pdfkit/api.py
+++ b/pdfkit/api.py
@@ -5,7 +5,7 @@ from .pdfkit import Configuration
 
 
 def from_url(url, output_path, options=None, toc=None, cover=None,
-             configuration=None, cover_first=False):
+             configuration=None, cover_first=False, timeout=None):
     """
     Convert file of files from URLs to PDF document
 
@@ -16,6 +16,7 @@ def from_url(url, output_path, options=None, toc=None, cover=None,
     :param cover: (optional) string with url/filename with a cover html page
     :param configuration: (optional) instance of pdfkit.configuration.Configuration()
     :param configuration_first: (optional) if True, cover always precedes TOC
+    :param timeout: (optional) int or float seconds to wait for wkhtmltopdf to convert input
 
     Returns: True on success
     """
@@ -23,11 +24,11 @@ def from_url(url, output_path, options=None, toc=None, cover=None,
     r = PDFKit(url, 'url', options=options, toc=toc, cover=cover,
                configuration=configuration, cover_first=cover_first)
 
-    return r.to_pdf(output_path)
+    return r.to_pdf(output_path, timeout)
 
 
 def from_file(input, output_path, options=None, toc=None, cover=None, css=None,
-              configuration=None, cover_first=False):
+              configuration=None, cover_first=False, timeout=None):
     """
     Convert HTML file or files to PDF document
 
@@ -39,6 +40,7 @@ def from_file(input, output_path, options=None, toc=None, cover=None, css=None,
     :param css: (optional) string with path to css file which will be added to a single input file
     :param configuration: (optional) instance of pdfkit.configuration.Configuration()
     :param configuration_first: (optional) if True, cover always precedes TOC
+    :param timeout: (optional) int or float seconds to wait for wkhtmltopdf to convert input
 
     Returns: True on success
     """
@@ -46,11 +48,11 @@ def from_file(input, output_path, options=None, toc=None, cover=None, css=None,
     r = PDFKit(input, 'file', options=options, toc=toc, cover=cover, css=css,
                configuration=configuration, cover_first=cover_first)
 
-    return r.to_pdf(output_path)
+    return r.to_pdf(output_path, timeout)
 
 
 def from_string(input, output_path, options=None, toc=None, cover=None, css=None,
-                configuration=None, cover_first=False):
+                configuration=None, cover_first=False, timeout=None):
     """
     Convert given string or strings to PDF document
 
@@ -62,6 +64,7 @@ def from_string(input, output_path, options=None, toc=None, cover=None, css=None
     :param css: (optional) string with path to css file which will be added to a input string
     :param configuration: (optional) instance of pdfkit.configuration.Configuration()
     :param configuration_first: (optional) if True, cover always precedes TOC
+    :param timeout: (optional) int or float seconds to wait for wkhtmltopdf to convert input
 
     Returns: True on success
     """
@@ -69,7 +72,7 @@ def from_string(input, output_path, options=None, toc=None, cover=None, css=None
     r = PDFKit(input, 'string', options=options, toc=toc, cover=cover, css=css,
                configuration=configuration, cover_first=cover_first)
 
-    return r.to_pdf(output_path)
+    return r.to_pdf(output_path, timeout)
 
 
 def configuration(**kwargs):

--- a/pdfkit/pdfkit.py
+++ b/pdfkit/pdfkit.py
@@ -190,11 +190,11 @@ class PDFKit(object):
         thread.start()
         proc = q.get()
         try:
-          stdout, stderr, exit_code = q.get(True, timeout)
-          self.handle_error(exit_code, stderr)
+            stdout, stderr, exit_code = q.get(True, timeout)
+            self.handle_error(exit_code, stderr)
         except Queue.Empty as e:
-          proc.terminate()
-          raise IOError('Command exceeded timeout of {0} sec.'.format(timeout))
+            proc.terminate()
+            raise IOError('Command exceeded timeout of {0} sec.'.format(timeout))
 
         # Since wkhtmltopdf sends its output to stderr we will capture it
         # and properly send to stdout

--- a/pdfkit/pdfkit.py
+++ b/pdfkit/pdfkit.py
@@ -69,7 +69,6 @@ class PDFKit(object):
         self.cover_first = cover_first
         self.css = css
         self.stylesheets = []
-        self.proc = None
 
     def _genargs(self, opts):
         """
@@ -140,10 +139,9 @@ class PDFKit(object):
         if exit_code == 0:
             return
 
-        # Sometimes wkhtmltopdf will exit with non-zero
-        # even if it finishes generation.
-        # If will display 'Done' in the second last line
-        if stderr.splitlines()[-2].strip() == 'Done':
+        # Sometimes wkhtmltopdf will exit with non-zero even if it finishes
+        # generation. It will display 'Done' in the second last line.
+        if re.search('\s*Done\s*\n[^\n]*$', stderr):
             return
 
         if 'cannot connect to X server' in stderr:

--- a/tests/pdfkit-tests.py
+++ b/tests/pdfkit-tests.py
@@ -416,6 +416,7 @@ class TestPDFKitGeneration(unittest.TestCase):
             fake_command = ['timeout', str(timeout + 5)]
         else:
             fake_command = ['sleep', str(timeout + 5)]
+
         r.command = lambda _: fake_command
         with self.assertRaises(IOError):
             r.to_pdf(timeout=timeout)

--- a/tests/pdfkit-tests.py
+++ b/tests/pdfkit-tests.py
@@ -408,5 +408,18 @@ class TestPDFKitGeneration(unittest.TestCase):
         raised_exception = cm.exception
         self.assertRegex(str(raised_exception), '^wkhtmltopdf exited with non-zero code 1. error:\nUnknown long argument --bad-option\r?\n')
 
+    def test_raise_error_if_timeout_exceeded(self):
+        r = pdfkit.PDFKit('<html><body>Hai!</body></html>', 'string',
+                          options={'bad-option': None})
+        timeout = 0.1
+        if sys.platform == 'win32':
+            fake_command = ['timeout', str(timeout + 5)]
+        else:
+            fake_command = ['sleep', str(timeout + 5)]
+        r.command = lambda _: fake_command
+        with self.assertRaises(IOError):
+            r.to_pdf(timeout=timeout)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/pdfkit-tests.py
+++ b/tests/pdfkit-tests.py
@@ -418,8 +418,11 @@ class TestPDFKitGeneration(unittest.TestCase):
             fake_command = ['sleep', str(timeout + 5)]
 
         r.command = lambda _: fake_command
-        with self.assertRaises(IOError):
+        with self.assertRaises(IOError) as cm:
             r.to_pdf(timeout=timeout)
+
+        raised_exception = cm.exception
+        self.assertRegex(str(raised_exception), '^Command exceeded timeout.*')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I noticed sometimes wkhtmltopdf will hang while converting a page. To keep things moving I wanted to just kill the conversion after a timeout, but doing this from the code calling pdfkit leaves the zombie wkhtmltopdf subprocess running. This PR adds a configurable timeout that cleans the process up.