### PR TITLE
Fix SyntaxWarning with literal equality check

### DIFF
--- a/pdfkit/source.py
+++ b/pdfkit/source.py
@@ -8,7 +8,7 @@ class Source(object):
         self.source = url_or_file
         self.type = type_
 
-        if self.type is 'file':
+        if self.type == 'file':
             self.checkFiles()
 
     def isUrl(self):


### PR DESCRIPTION
When using this library I'm getting this SyntaxWarning:
`.venv/lib/python3.8/site-packages/pdfkit/source.py:11: SyntaxWarning: "is" with a literal. Did you mean "=="?`

Checking your code, it looks like `type_` is always a string, either `string` or `file`.