### PR TITLE
Remove python 3.2 and 3.3 and add 3.6, 3.7, 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: python
 python:
   - 2.7
-  - 3.2
-  - 3.3
   - 3.4
   - 3.5
+  - 3.6
+  - 3.7
+  - 3.8
 before_script: "./travis/before-script.sh"
 script: nosetests -w tests
 notifications:


### PR DESCRIPTION
It looks like 3.2 and 3.3 are not available on travis anymore
https://travis-ci.org/github/JazzCore/python-pdfkit/jobs/665811141