### PR TITLE
Support Python3.8

### DIFF
--- a/pdfkit/source.py
+++ b/pdfkit/source.py
@@ -8,7 +8,7 @@ class Source(object):
         self.source = url_or_file
         self.type = type_
 
-        if self.type is 'file':
+        if self.type == 'file':
             self.checkFiles()
 
     def isUrl(self):


### PR DESCRIPTION
Python 3.8 throws warning
```
source.py:11: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if self.type is 'file':
```