### PR TITLE
Replaced is by == in source.py

### DIFF
--- a/pdfkit/source.py
+++ b/pdfkit/source.py
@@ -8,7 +8,7 @@ class Source(object):
         self.source = url_or_file
         self.type = type_
 
-        if self.type is 'file':
+        if self.type == 'file':
             self.checkFiles()
 
     def isUrl(self):


### PR DESCRIPTION
The file source.py contained

```python3
if self.type is 'file':
```
Here == is more convenient than the is keyword so I replaced it.