### PR TITLE
Changed where to where.exe

### DIFF
--- a/pdfkit/configuration.py
+++ b/pdfkit/configuration.py
@@ -13,7 +13,7 @@ class Configuration(object):
         if not self.wkhtmltopdf:
             if sys.platform == 'win32':
                 self.wkhtmltopdf = subprocess.Popen(
-                    ['where', 'wkhtmltopdf'], stdout=subprocess.PIPE).communicate()[0].strip()
+                    ['where.exe', 'wkhtmltopdf'], stdout=subprocess.PIPE).communicate()[0].strip()
             else:
                 self.wkhtmltopdf = subprocess.Popen(
                     ['which', 'wkhtmltopdf'], stdout=subprocess.PIPE).communicate()[0].strip()


### PR DESCRIPTION
Changed where to where.exe as Powershell has a native where command which was messing up the script if run through a Powershell console on Windows