### PR TITLE
Update brew install command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Installation
 
 .. code-block:: bash
 
-	$ brew install caskroom/cask/wkhtmltopdf
+	$ brew install homebrew/cask/wkhtmltopdf
 
 **Warning!** Version in debian/ubuntu repos have reduced functionality (because it compiled without the wkhtmltopdf QT patches), such as adding outlines, headers, footers, TOC etc. To use this options you should install static binary from `wkhtmltopdf <http://wkhtmltopdf.org/>`_ site or you can use `this script <https://github.com/JazzCore/python-pdfkit/blob/master/travis/before-script.sh>`_.
 


### PR DESCRIPTION
Current version rises an error:
Error: caskroom/cask was moved. Tap homebrew/cask instead.