### PR TITLE
Raise exceptions control

### DIFF
--- a/pdfkit/api.py
+++ b/pdfkit/api.py
@@ -4,8 +4,8 @@ from .pdfkit import PDFKit
 from .pdfkit import Configuration
 
 
-def from_url(url, output_path=None, options=None, toc=None, cover=None,
-             configuration=None, cover_first=False, verbose=False):
+def from_url(url, output_path=None, options=None, toc=None, cover=None, configuration=None, cover_first=False,
+             verbose=False, raise_exceptions=True):
     """
     Convert file of files from URLs to PDF document
 
@@ -21,14 +21,14 @@ def from_url(url, output_path=None, options=None, toc=None, cover=None,
     Returns: True on success
     """
 
-    r = PDFKit(url, 'url', options=options, toc=toc, cover=cover,
-               configuration=configuration, cover_first=cover_first, verbose=verbose)
+    r = PDFKit(url, 'url', options=options, toc=toc, cover=cover, configuration=configuration, cover_first=cover_first,
+               verbose=verbose, raise_exceptions=raise_exceptions)
 
     return r.to_pdf(output_path)
 
 
 def from_file(input, output_path=None, options=None, toc=None, cover=None, css=None,
-              configuration=None, cover_first=False, verbose=False):
+              configuration=None, cover_first=False, verbose=False, raise_exceptions=True):
     """
     Convert HTML file or files to PDF document
 
@@ -45,14 +45,14 @@ def from_file(input, output_path=None, options=None, toc=None, cover=None, css=N
     Returns: True on success
     """
 
-    r = PDFKit(input, 'file', options=options, toc=toc, cover=cover, css=css,
-               configuration=configuration, cover_first=cover_first, verbose=verbose)
+    r = PDFKit(input, 'file', options=options, toc=toc, cover=cover, css=css, configuration=configuration,
+               cover_first=cover_first, verbose=verbose, raise_exceptions=raise_exceptions)
 
     return r.to_pdf(output_path)
 
 
 def from_string(input, output_path=None, options=None, toc=None, cover=None, css=None,
-                configuration=None, cover_first=False, verbose=False):
+                configuration=None, cover_first=False, verbose=False, raise_exceptions=True):
     """
     Convert given string or strings to PDF document
 
@@ -69,8 +69,8 @@ def from_string(input, output_path=None, options=None, toc=None, cover=None, css
     Returns: True on success
     """
 
-    r = PDFKit(input, 'string', options=options, toc=toc, cover=cover, css=css,
-               configuration=configuration, cover_first=cover_first, verbose=verbose)
+    r = PDFKit(input, 'string', options=options, toc=toc, cover=cover, css=css, configuration=configuration,
+               cover_first=cover_first, verbose=verbose, raise_exceptions=raise_exceptions)
 
     return r.to_pdf(output_path)
 

--- a/pdfkit/pdfkit.py
+++ b/pdfkit/pdfkit.py
@@ -38,8 +38,8 @@ class PDFKit(object):
         def __str__(self):
             return self.msg
 
-    def __init__(self, url_or_file, type_, options=None, toc=None, cover=None,
-                 css=None, configuration=None, cover_first=False, verbose=False):
+    def __init__(self, url_or_file, type_, options=None, toc=None, cover=None, css=None, configuration=None,
+                 cover_first=False, verbose=False, raise_exceptions=True):
 
         self.source = Source(url_or_file, type_)
         self.configuration = (Configuration() if configuration is None
@@ -64,6 +64,7 @@ class PDFKit(object):
         self.verbose = verbose
         self.css = css
         self.stylesheets = []
+        self.raise_exceptions = raise_exceptions
 
     def _genargs(self, opts):
         """
@@ -198,7 +199,9 @@ class PDFKit(object):
         stderr = stderr or stdout or b""
         stderr = stderr.decode('utf-8', errors='replace')
         exit_code = result.returncode
-        self.handle_error(exit_code, stderr)
+        # don't raise errors  if we want to get clean wkhtmltopdf output
+        if self.raise_exceptions:
+            self.handle_error(exit_code, stderr)
 
         # Since wkhtmltopdf sends its output to stderr we will capture it
         # and properly send to stdout

--- a/tests/pdfkit-tests.py
+++ b/tests/pdfkit-tests.py
@@ -493,14 +493,17 @@ class TestPDFKitGeneration(unittest.TestCase):
         self.assertEqual(output[:4].decode('utf-8'), '%PDF')
 
     def test_raise_exceptions_kwarg(self):
+        # exception raised
         r = pdfkit.PDFKit('clearlywrongurl.asdf', 'url', raise_exceptions=True)
         with self.assertRaises(IOError):
             r.to_pdf()
 
+        # exception not raised
         r = pdfkit.PDFKit('clearlywrongurl.asdf', 'url', raise_exceptions=False)
-        with not self.assertRaises(IOError):
+        try:
             r.to_pdf()
-
+        except IOError:
+            self.fail("r.to_pdf() raised an IOError exception despite 'raise_exceptions=False' kwarg")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/pdfkit-tests.py
+++ b/tests/pdfkit-tests.py
@@ -505,5 +505,6 @@ class TestPDFKitGeneration(unittest.TestCase):
         except IOError:
             self.fail("r.to_pdf() raised an IOError exception despite 'raise_exceptions=False' kwarg")
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/pdfkit-tests.py
+++ b/tests/pdfkit-tests.py
@@ -492,5 +492,15 @@ class TestPDFKitGeneration(unittest.TestCase):
         output = r.to_pdf()
         self.assertEqual(output[:4].decode('utf-8'), '%PDF')
 
+    def test_raise_exceptions_kwarg(self):
+        r = pdfkit.PDFKit('clearlywrongurl.asdf', 'url', raise_exceptions=True)
+        with self.assertRaises(IOError):
+            r.to_pdf()
+
+        r = pdfkit.PDFKit('clearlywrongurl.asdf', 'url', raise_exceptions=False)
+        with not self.assertRaises(IOError):
+            r.to_pdf()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Hi all, I've been working with pdfkit and found several cases where wkhtmltopdf outputs errors, but still generates a pdf.  I would like to be able to manually control how the pdf-kit responds to errors.

ps: I apologize if I violate protocol in any way, this is my first time doing pull request to opensource.