### PR TITLE
BUG: Check for equality, not for identity

### DIFF
--- a/pdfkit/source.py
+++ b/pdfkit/source.py
@@ -8,7 +8,7 @@ class Source(object):
         self.source = url_or_file
         self.type = type_
 
-        if self.type is 'file':
+        if self.type == 'file':
             self.checkFiles()
 
     def isUrl(self):


### PR DESCRIPTION
```
>>> a = "file"
>>> b = "fi"
>>> c = "le"
>>> a == b+c
True
>>> a is b+c
False
```